### PR TITLE
Sample1A: Presenterで分岐処理する必要がなかったためEntityを渡す

### DIFF
--- a/Sample1A/Modules/GithubReposSearch/Presenter/GithubRepoSearchPresenter.swift
+++ b/Sample1A/Modules/GithubReposSearch/Presenter/GithubRepoSearchPresenter.swift
@@ -11,7 +11,7 @@ import Foundation
 protocol GithubRepoSearchPresentation: AnyObject {
     func viewDidLoad()
     func search(_ word: String)
-    func selectItem(with indexPath: IndexPath)
+    func select(_ entity: GithubRepoEntity)
 }
 
 protocol GithubRepoSearchView: AnyObject {
@@ -79,19 +79,8 @@ extension GithubRepoSearchPresenter: GithubRepoSearchPresentation {
 
     // MARK: - wireframe
 
-    func selectItem(with indexPath: IndexPath) {
-        switch DisplayGithubRepoData.Section(rawValue: indexPath.section)! {
-        case .recommend:
-            guard (0 ..< recommends.count).contains(indexPath.row) else { return }
-
-            let entity = recommends[indexPath.row]
-            dependency.wireframe.presentDetail(entity)
-        case .search:
-            guard (0 ..< searchResultEntities.count).contains(indexPath.row) else { return }
-
-            let entity = searchResultEntities[indexPath.row]
-            dependency.wireframe.presentDetail(entity)
-        }
+    func select(_ entity: GithubRepoEntity) {
+        dependency.wireframe.presentDetail(entity)
     }
 }
 

--- a/Sample1A/Modules/GithubReposSearch/Views/GithubRepoSearchViewController.swift
+++ b/Sample1A/Modules/GithubReposSearch/Views/GithubRepoSearchViewController.swift
@@ -94,7 +94,8 @@ extension GithubRepoSearchViewController: UITableViewDataSource {
 
 extension GithubRepoSearchViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        dependency.presenter.selectItem(with: indexPath)
+        let entity = displayData.item(with: indexPath)!
+        dependency.presenter.select(entity)
     }
 }
 

--- a/Sample1ATests/GithubRepoSearch/GithubRepoSearchPresenterTests.swift
+++ b/Sample1ATests/GithubRepoSearch/GithubRepoSearchPresenterTests.swift
@@ -76,17 +76,26 @@ class GithubRepoSearchPresenterTests: XCTestCase {
 
                 XCTContext.runActivity(named: "Section: 0をタップ") { _ in
                     XCTContext.runActivity(named: "row: 0をタップ") { _ in
-                        presenter.selectItem(with: IndexPath(row: 0, section: section))
+                        let indexPath = IndexPath(row: 0, section: section)
+
+                        let entity = view.displayGithubRepoData.item(with: indexPath)!
+                        presenter.select(entity)
                         XCTAssertEqual(router.githubRepoEntity?.name, "objcio/issue-13-viper")
                     }
 
                     XCTContext.runActivity(named: "row: 1をタップ") { _ in
-                        presenter.selectItem(with: IndexPath(row: 1, section: section))
+                        let indexPath = IndexPath(row: 1, section: section)
+
+                        let entity = view.displayGithubRepoData.item(with: indexPath)!
+                        presenter.select(entity)
                         XCTAssertEqual(router.githubRepoEntity?.name, "objcio/issue-13-viper-swift")
                     }
 
                     XCTContext.runActivity(named: "row: 2をタップ") { _ in
-                        presenter.selectItem(with: IndexPath(row: 2, section: section))
+                        let indexPath = IndexPath(row: 2, section: section)
+
+                        let entity = view.displayGithubRepoData.item(with: indexPath)!
+                        presenter.select(entity)
                         XCTAssertEqual(router.githubRepoEntity?.name, "pedrohperalta/Articles-iOS-VIPER")
                     }
                 }
@@ -125,7 +134,10 @@ class GithubRepoSearchPresenterTests: XCTestCase {
                     }
 
                     XCTContext.runActivity(named: "タップ") { _ in
-                        self.presenter.selectItem(with: IndexPath(row: 0, section: section))
+                        let indexPath = IndexPath(row: 0, section: section)
+
+                        let entity = self.view.displayGithubRepoData.item(with: indexPath)!
+                        self.presenter.select(entity)
                         XCTAssertEqual(self.router.githubRepoEntity?.name, "name0")
                     }
                 }


### PR DESCRIPTION
- PresenterからRouterを呼び出してる
  - Presenterの内部データを使ってる
    - Presenterからデータを取り出して表示しているのに内部データ使ってる
      - 違いがあったら困る...
