### PR TITLE
AppDependenciesの定義位置をトップに移動

### DIFF
--- a/Sample1A/AppDependencies.swift
+++ b/Sample1A/AppDependencies.swift
@@ -8,6 +8,14 @@
 
 import UIKit
 
+protocol AppDependencies {
+    // UIViewControllerを返すようにしてほしい
+    // 依存性のごちゃごちゃはassembleでやって外に出すときはUIViewController
+    func assembleGithubRepoSearchModule() -> UIViewController
+
+    func assembleGithubRepoDetailModule(githubRepoEntity: GithubRepoEntity) -> UIViewController
+}
+
 // クリーンアーキテクチャ本でいうところの「メインモジュール」
 // テスト時に必要があれば入れ替える
 public struct AppDefaultDependencies {
@@ -18,14 +26,6 @@ public struct AppDefaultDependencies {
     public func rootViewController() -> UIViewController {
         return assembleGithubRepoSearchModule()
     }
-}
-
-protocol AppDependencies {
-    // UIViewControllerを返すようにしてほしい
-    // 依存性のごちゃごちゃはassembleでやって外に出すときはUIViewController
-    func assembleGithubRepoSearchModule() -> UIViewController
-
-    func assembleGithubRepoDetailModule(githubRepoEntity: GithubRepoEntity) -> UIViewController
 }
 
 extension AppDefaultDependencies: AppDependencies {


### PR DESCRIPTION
protocolは具象型よりも上に定義したい