### PR TITLE
Use Identifiable

### DIFF
--- a/Sample1A/Common/Entity/GithubRepoEntity.swift
+++ b/Sample1A/Common/Entity/GithubRepoEntity.swift
@@ -8,13 +8,15 @@
 
 import Foundation
 
-struct GithubRepoEntity: Decodable, Equatable {
+struct GithubRepoEntity: Decodable, Identifiable, Equatable {
+    let id: Int
     let name: String
     let htmlURL: URL
     let description: String?
     let stargazersCount: Int?
 
     enum CodingKeys: String, CodingKey {
+        case id
         case name
         case htmlURL = "html_url"
         case description
@@ -24,6 +26,6 @@ struct GithubRepoEntity: Decodable, Equatable {
     // 同じものかどうかを比較できるようにしておきます。
     // 主にテストコードで利用します。
     static func == (lhs: Self, rhs: Self) -> Bool {
-        return lhs.htmlURL == rhs.htmlURL
+        return lhs.id == rhs.id
     }
 }

--- a/Sample1A/Modules/GithubReposSearch/Interactor/GithubRepoRecomendInteractor.swift
+++ b/Sample1A/Modules/GithubReposSearch/Interactor/GithubRepoRecomendInteractor.swift
@@ -12,18 +12,21 @@ struct GithubRepoRecommendInteractor: UseCase {
     func execute(_ parameters: Void = (), completion: ((Result<[GithubRepoEntity], Error>) -> ())?) {
         let entities = [
             GithubRepoEntity(
+                id: 20638417,
                 name: "objcio/issue-13-viper",
                 htmlURL: URL(string: "https://github.com/objcio/issue-13-viper")!,
                 description: "Mutualmobile社の人がobjc.ioに寄稿したオリジナルなVIPERサンプル",
                 stargazersCount: nil
             ),
             GithubRepoEntity(
+                id: 20638435,
                 name: "objcio/issue-13-viper-swift",
                 htmlURL:  URL(string: "https://github.com/objcio/issue-13-viper-swift")!,
                 description: "オリジナルなVIPERサンプルをSwiftで書き換えたもの",
                 stargazersCount: nil
             ),
             GithubRepoEntity(
+                id: 54735381,
                 name: "pedrohperalta/Articles-iOS-VIPER",
                 htmlURL:  URL(string: "https://github.com/pedrohperalta/Articles-iOS-VIPER")!,
                 description: "PedroさんのVIPER実装",

--- a/Sample1ATests/GithubRepoSearch/GithubRepoSearchPresenterTests.swift
+++ b/Sample1ATests/GithubRepoSearch/GithubRepoSearchPresenterTests.swift
@@ -111,12 +111,14 @@ class GithubRepoSearchPresenterTests: XCTestCase {
         XCTContext.runActivity(named: "searchを呼び出した後") { _ in
             searchInteractor.stubData = [
                 .init(
+                    id: 1,
                     name: "name0",
                     htmlURL: URL(string: "http://example.com/0")!,
                     description: "",
                     stargazersCount: 0
                 ),
                 .init(
+                    id: 2,
                     name: "name1",
                     htmlURL: URL(string: "http://example.com/1")!,
                     description: "",

--- a/Sample1ATests/GithubRepoSearch/GithubRepoSearchRouterTests.swift
+++ b/Sample1ATests/GithubRepoSearch/GithubRepoSearchRouterTests.swift
@@ -28,6 +28,7 @@ class GithubRepoSearchRouterTests: XCTestCase {
     func testDetailViewControllerIsPushed() {
         setUp()
         let entity = GithubRepoEntity(
+            id: 1,
             name: "name0",
             htmlURL: URL(string: "html://example.com")!,
             description: "",

--- a/Sample1ATests/GithubRepoSearch/GithubRepoSortInteractorTests.swift
+++ b/Sample1ATests/GithubRepoSearch/GithubRepoSortInteractorTests.swift
@@ -16,18 +16,21 @@ class GithubRepoSortInteractorTests: XCTestCase {
 
         let stubData: [GithubRepoEntity] = [
             .init(
+                id: 1,
                 name: "name0",
                 htmlURL: URL(string: "http://example.com/0")!,
                 description: "",
                 stargazersCount: 0
             ),
             .init(
+                id: 2,
                 name: "name1",
                 htmlURL: URL(string: "http://example.com/1")!,
                 description: "",
                 stargazersCount: 1
             ),
             .init(
+                id: 3,
                 name: "name2",
                 htmlURL: URL(string: "http://example.com/2")!,
                 description: "",
@@ -63,18 +66,21 @@ class GithubRepoSortInteractorTests: XCTestCase {
 
         let stubData: [GithubRepoEntity] = [
             .init(
+                id: 1,
                 name: "name0",
                 htmlURL: URL(string: "http://example.com/0")!,
                 description: "",
                 stargazersCount: 0
             ),
             .init(
+                id: 2,
                 name: "name1",
                 htmlURL: URL(string: "http://example.com/1")!,
                 description: "",
                 stargazersCount: 1
             ),
             .init(
+                id: 3,
                 name: "name2",
                 htmlURL: URL(string: "http://example.com/2")!,
                 description: "",


### PR DESCRIPTION
- EntityのEquatableでurlを対象にしていたが本当はidが識別子であるはず...
- idをEquatableにしてもよいがせっかくなのでIdentifiableプロトコルを使う
- Identifiableを使っても自動的にEquatableになるわけじゃない