### PR TITLE
Presenterのエラーハンドリング部分をテストコードでカバーする

### DIFF
--- a/VIPERBook1Sample.xcodeproj/xcshareddata/xcschemes/VIPERBook1Sample.xcscheme
+++ b/VIPERBook1Sample.xcodeproj/xcshareddata/xcschemes/VIPERBook1Sample.xcscheme
@@ -26,7 +26,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">


### PR DESCRIPTION
正常系だけのテストではカバーできていない

<img width="1327" alt="スクリーンショット 2020-01-03 13 37 03" src="https://user-images.githubusercontent.com/1137860/71714735-5c5cc100-2e52-11ea-83d5-3960730be0fc.png">

2つのエラーに対してテストコードを書いて検証する

- キャンセルのエラーはスルー
- キャンセルでないエラーはそのエラーを取得
