### PR TITLE
循環参照されているViewControllerの解決

### DIFF
--- a/Sample1A/Modules/GithubReposSearch/Router/GithubRepoSearchRouter.swift
+++ b/Sample1A/Modules/GithubReposSearch/Router/GithubRepoSearchRouter.swift
@@ -11,7 +11,7 @@ import UIKit
 // MARK: - Contract
 
 protocol GithubReposSearchWireframe {
-    var searchViewController: UIViewController { get set }
+    var searchViewController: UIViewController { get }
 
     func presentDetail(_ githubRepoEntity: GithubRepoEntity)
     func presentAlert(_ error: Error)

--- a/Sample1A/Modules/GithubReposSearch/Router/GithubRepoSearchRouter.swift
+++ b/Sample1A/Modules/GithubReposSearch/Router/GithubRepoSearchRouter.swift
@@ -23,7 +23,7 @@ struct GithubRepoSearchRouter: GithubReposSearchWireframe {
 
     let appDependencies: AppDependencies
     // presentしたい際に使う
-    var searchViewController: UIViewController
+    unowned var searchViewController: UIViewController
 
     func presentDetail(_ githubRepoEntity: GithubRepoEntity) {
         let viewController = appDependencies.assembleGithubRepoDetailModule(


### PR DESCRIPTION
# 概要

ViewControllerが循環参照しないようにする

# 問題点

下記のように3つが循環して強参照しあっている

- ViewControllerがPresenterを保持
- PresenterがRouterを保持
- RouterがViewControllerを保持

そのため、NavigationControllerがViewControllerをpopしてもRouterからの強参照が終わらず、
結果ViewControllerが破棄されていない。

# 解決方法

- RouterはViewControllerを強参照しないようにする
  - weakにしてもいいがViewControllerがnilの場合という現実的でない処理に対処することになるためそれは避ける


